### PR TITLE
Added a new example - debugSetup()

### DIFF
--- a/Setup_Example/readme.md
+++ b/Setup_Example/readme.md
@@ -1,0 +1,22 @@
+# Example 3
+
+This example extends the simple example by including the serial port setup. This is useful for projects where the serial port will only be used for debugging.
+
+A new definition, ```debugSetup()``` replaces ```Serial.begin()```, allowing the Serial library to be completely excluded automatically if debugging is disabled.
+
+You can even combine ```debugSetup()``` with ```Serial.begin()```, using two different baud rates. To do this, add the ```Serial.begin()``` line above the ```debugSetup()``` line.
+
+Full code:
+```
+#define DEBUG 1
+
+#if DEBUG == 1
+#define debug(x) Serial.print(x)
+#define debugln(x) Serial.println(x)
+#define debugSetup(x) Serial.begin(x)
+#else
+#define debug(x)
+#define debugln(x)
+#define debugSetup(x)
+#endif
+```

--- a/Setup_Example/setup.ino
+++ b/Setup_Example/setup.ino
@@ -1,0 +1,41 @@
+#include <Arduino.h>
+
+#define BAUD_RATE 115200
+#define DEBUG 0
+
+#if DEBUG == 1
+#define debug(x) Serial.print(x)
+#define debugln(x) Serial.println(x)
+#define debugSetup(x) Serial.begin(x)
+#else
+#define debug(x)
+#define debugln(x)
+#define debugSetup(x)
+#endif
+
+int addOne(int inX) {
+    debug("Received value:");
+    debugln(inX);
+    
+    // Other processing done here
+
+    debugln("Returning.");
+    return inX + 1;
+}
+
+void setup() {
+    Serial.begin(BAUD_RATE);
+    debugSetup(9600); // Overrides the above line if DEBUG = 1
+    Serial.println("Runtime message - Setup Complete");
+    debugln("Debug message - Only printed if DEBUG = 1.");
+}
+
+void loop () {
+    static unsigned long counter = 0;
+    unsigned long b = addOne(counter);
+    debug("Counter:");
+    debugln(b);
+
+    // Emulate other processing being done herek
+    delay(5000);
+}


### PR DESCRIPTION
I've created a new example based on a technique that I use when debugging. This allows you to setup the serial port as part of the DEBUG flag, and completely exclude the Serial library if it isn't used elsewhere in the sketch. It also lets you use a different baud rate for debugging, should that be useful.

A code example is included and a readme.md file.